### PR TITLE
5/1 18:57

### DIFF
--- a/batch/build.gradle
+++ b/batch/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation platform('software.amazon.awssdk:bom:2.20.48')
     implementation 'software.amazon.awssdk:comprehend'
     implementation 'software.amazon.awssdk:rekognition'

--- a/batch/src/main/java/com/ggukgguk/batch/BatchApplication.java
+++ b/batch/src/main/java/com/ggukgguk/batch/BatchApplication.java
@@ -1,5 +1,6 @@
 package com.ggukgguk.batch;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,8 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @EnableBatchProcessing
 @SpringBootApplication
 public class BatchApplication {
-
-    public static void main(String[] args) {
+    public static void main(String[] args) throws JsonProcessingException {
          SpringApplication.run(BatchApplication.class, args);
     }
 

--- a/batch/src/main/java/com/ggukgguk/batch/checkContent/job/CheckContentConfig.java
+++ b/batch/src/main/java/com/ggukgguk/batch/checkContent/job/CheckContentConfig.java
@@ -1,15 +1,12 @@
 package com.ggukgguk.batch.checkContent.job;
 
 import com.ggukgguk.batch.checkContent.vo.MediaFile;
-import com.ggukgguk.batch.common.service.RekognizeService;
-import com.ggukgguk.batch.extractKeyword.vo.Record;
-import com.ggukgguk.batch.extractKeyword.vo.RecordKeyword;
+import com.ggukgguk.batch.checkContent.service.RekognizeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
-import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
@@ -21,8 +18,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.rekognition.RekognitionClient;
 import ws.schild.jave.EncoderException;
 import ws.schild.jave.MultimediaObject;
 import ws.schild.jave.ScreenExtractor;

--- a/batch/src/main/java/com/ggukgguk/batch/checkContent/service/RekognizeService.java
+++ b/batch/src/main/java/com/ggukgguk/batch/checkContent/service/RekognizeService.java
@@ -1,4 +1,4 @@
-package com.ggukgguk.batch.common.service;
+package com.ggukgguk.batch.checkContent.service;
 
 public interface RekognizeService {
     public boolean detectModLabel(String sourceImage);

--- a/batch/src/main/java/com/ggukgguk/batch/checkContent/service/RekognizeServiceImpl.java
+++ b/batch/src/main/java/com/ggukgguk/batch/checkContent/service/RekognizeServiceImpl.java
@@ -1,7 +1,8 @@
-package com.ggukgguk.batch.common.service;
+package com.ggukgguk.batch.checkContent.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rekognition.RekognitionClient;
@@ -15,7 +16,7 @@ import java.io.InputStream;
 import java.util.List;
 
 @Slf4j
-@StepScope
+@Component
 public class RekognizeServiceImpl implements RekognizeService{
     @Override
     public boolean detectModLabel(String sourceImage) {

--- a/batch/src/main/java/com/ggukgguk/batch/common/config/BeansConfig.java
+++ b/batch/src/main/java/com/ggukgguk/batch/common/config/BeansConfig.java
@@ -1,22 +1,25 @@
 package com.ggukgguk.batch.common.config;
 
-import com.ggukgguk.batch.common.service.ComprehendService;
-import com.ggukgguk.batch.common.service.ComprehendServiceImpl;
-import com.ggukgguk.batch.common.service.RekognizeService;
-import com.ggukgguk.batch.common.service.RekognizeServiceImpl;
-import org.springframework.batch.core.configuration.annotation.StepScope;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ggukgguk.batch.extractKeyword.service.ColorService;
+import com.ggukgguk.batch.extractKeyword.service.ColorServiceImpl;
+import com.ggukgguk.batch.extractKeyword.service.ComprehendService;
+import com.ggukgguk.batch.extractKeyword.service.ComprehendServiceImpl;
+import com.ggukgguk.batch.checkContent.service.RekognizeService;
+import com.ggukgguk.batch.checkContent.service.RekognizeServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class BeansConfig {
     @Bean
-    public ComprehendService comprehendService() {
-        return new ComprehendServiceImpl();
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 
     @Bean
-    public RekognizeService rekognizeService() {
-        return new RekognizeServiceImpl();
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/job/ExtractKeywordConfig.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/job/ExtractKeywordConfig.java
@@ -1,17 +1,16 @@
 package com.ggukgguk.batch.extractKeyword.job;
 
-import com.ggukgguk.batch.common.service.ComprehendService;
-import com.ggukgguk.batch.common.service.ComprehendServiceImpl;
-import com.ggukgguk.batch.extractKeyword.vo.Record;
-import com.ggukgguk.batch.extractKeyword.vo.RecordKeyword;
-import com.ggukgguk.batch.extractKeyword.vo.RecordKeywordExtended;
+import com.ggukgguk.batch.extractKeyword.service.ColorService;
+import com.ggukgguk.batch.extractKeyword.service.ComprehendService;
+import com.ggukgguk.batch.extractKeyword.service.GgukggukNlpService;
+import com.ggukgguk.batch.extractKeyword.service.GgukggukNlpServiceImpl;
+import com.ggukgguk.batch.extractKeyword.vo.*;
 import com.ggukgguk.batch.extractKeyword.writer.ItemListWriter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
-import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
@@ -29,10 +28,7 @@ import org.springframework.jdbc.core.BeanPropertyRowMapper;
 
 import javax.sql.DataSource;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 @Configuration
 @RequiredArgsConstructor
@@ -41,7 +37,8 @@ public class ExtractKeywordConfig {
     private final JobBuilderFactory jobBuilderFactory;
     private final StepBuilderFactory stepBuilderFactory;
     private final DataSource dataSource;
-    private final ComprehendService comprehendService;
+    private final GgukggukNlpService ggukggukNlpService;
+    private final ColorService colorService;
 
     private static final int chunkSize = 10;
 
@@ -50,6 +47,8 @@ public class ExtractKeywordConfig {
         return jobBuilderFactory.get("extractKeywordJob")
                 .start(getKeywordsStep())
                 .next(countKeywordsStep())
+                .next(setDiaryMainKeywordStep())
+                .next(setDiaryColorStep())
                 .build();
     }
 
@@ -57,7 +56,7 @@ public class ExtractKeywordConfig {
     public Step getKeywordsStep() {
         return stepBuilderFactory.get("getKeywordsStep")
                 .<Record, List<RecordKeyword>> chunk(chunkSize)
-                .reader(recordReader(null))
+                .reader(recordReader(0, 0))
                 .processor(recordProcessor())
                 .writer(recordWriter())
                 .build();
@@ -67,19 +66,37 @@ public class ExtractKeywordConfig {
     public Step countKeywordsStep() {
         return stepBuilderFactory.get("countKeywordsStep")
                 .<RecordKeywordExtended, RecordKeywordExtended> chunk(chunkSize)
-                .reader(recordKeywordReader(null))
+                .reader(recordKeywordReader(0, 0))
                 .writer(recordKeywordWriter())
+                .build();
+    }
+
+    @Bean
+    public Step setDiaryMainKeywordStep() {
+        return stepBuilderFactory.get("setDiaryMainKeywordStep")
+                .<DiaryKeywordAndColor, DiaryKeywordAndColor> chunk(chunkSize)
+                .reader(diaryKeywordReader(0, 0))
+                .writer(diaryKeywordWriter())
+                .build();
+    }
+
+    @Bean
+    public Step setDiaryColorStep() {
+        return stepBuilderFactory.get("setDiaryColorStep")
+                .<Diary, List<DiaryKeywordAndColor>> chunk(chunkSize)
+                .reader(diaryReader(0, 0))
+                .processor(fetchDiaryColorProcessor())
+                .writer(diaryWriter())
                 .build();
     }
 
     @Bean
     @StepScope
     public JdbcCursorItemReader<Record> recordReader(
-            @Value("#{jobParameters[executionDate]}") Date executionDate) {
-
-        int year = executionDate.getYear();
-        int month = executionDate.getMonth();
-        Date startDate = new Date(year, month, 1);
+            @Value("#{jobParameters[year]}") int year,
+            @Value("#{jobParameters[month]}") int month) {
+        Calendar calendar = new GregorianCalendar(year, month - 1, 1);
+        Date startDate = calendar.getTime();
 
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -99,7 +116,8 @@ public class ExtractKeywordConfig {
     @Bean
     public ItemProcessor<Record, List<RecordKeyword>> recordProcessor() {
         return record -> {
-            List<RecordKeyword> result = comprehendService.extractKeywordFromRecord(record);
+//            List<RecordKeyword> result = comprehendService.extractKeywordFromRecord(record);
+            List<RecordKeyword> result = ggukggukNlpService.extractKeywordFromRecord(record);
             return result;
         };
     }
@@ -121,11 +139,10 @@ public class ExtractKeywordConfig {
     @Bean
     @StepScope
     public JdbcCursorItemReader<RecordKeywordExtended> recordKeywordReader(
-            @Value("#{jobParameters[executionDate]}") Date executionDate) {
-
-        int year = executionDate.getYear();
-        int month = executionDate.getMonth();
-        Date startDate = new Date(year, month, 1);
+            @Value("#{jobParameters[year]}") int year,
+            @Value("#{jobParameters[month]}") int month) {
+        Calendar calendar = new GregorianCalendar(year, month - 1, 1);
+        Date startDate = calendar.getTime();
 
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -136,7 +153,7 @@ public class ExtractKeywordConfig {
                 .sql("SELECT YEAR(r.record_created_at) AS 'diary_year', MONTH(r.record_created_at) AS 'diary_month', r.member_id, rk.record_keyword FROM record_keyword rk\n" +
                         "LEFT JOIN record r \n" +
                         "ON r.record_id = rk.record_id\n" +
-                        "WHERE r.record_created_at BETWEEN '" + format.format(startDate) +"' 00:00" +
+                        "WHERE r.record_created_at BETWEEN '" + format.format(startDate) + " 00:00'" +
                         "\tAND DATE_ADD('" + format.format(startDate) + " 00:00', INTERVAL +1 month);") // Job 파라미터에서 받아오도록 수정하기
                 .name("recordKeywordReader")
                 .build();
@@ -185,4 +202,123 @@ public class ExtractKeywordConfig {
                 .build();
     }
 
+    @Bean
+    @StepScope
+    public JdbcCursorItemReader<DiaryKeywordAndColor> diaryKeywordReader(
+            @Value("#{jobParameters[year]}") int year,
+            @Value("#{jobParameters[month]}") int month) {
+        return new JdbcCursorItemReaderBuilder<DiaryKeywordAndColor>()
+                .fetchSize(chunkSize)
+                .dataSource(dataSource)
+                .rowMapper(new BeanPropertyRowMapper<>(DiaryKeywordAndColor.class))
+                /* freq가 가장 높은 행을 가져오는 쿼리
+                SELECT dk.diary_id, dk.diary_keyword, dk.diary_freq
+                FROM (
+                    SELECT diary_id, diary_keyword, diary_freq
+                    FROM diary_keyword d
+                    WHERE diary_freq = (
+                      SELECT MAX(diary_freq)
+                      FROM diary_keyword
+                      WHERE diary_id = d.diary_id
+                    )
+                ) dk
+                LEFT JOIN diary d
+                ON dk.diary_id = d.diary_id
+                WHERE d.diary_year = 2023 AND d.diary_month = 4;
+                */
+                .sql("SELECT dk.diary_id, dk.diary_keyword, dk.diary_freq\n" +
+                        "FROM (\n" +
+                        "\tSELECT diary_id, diary_keyword, diary_freq\n" +
+                        "\tFROM diary_keyword d\n" +
+                        "\tWHERE diary_freq = (\n" +
+                        "\t  SELECT MAX(diary_freq)\n" +
+                        "\t  FROM diary_keyword\n" +
+                        "\t  WHERE diary_id = d.diary_id\n" +
+                        "\t)) dk\n" +
+                        "LEFT JOIN diary d \n" +
+                        "ON dk.diary_id = d.diary_id\n" +
+                        "WHERE d.diary_year = " + year + " AND d.diary_month = " + month) // Job 파라미터에서 받아오도록 수정하기
+                .name("diaryKeywordReader")
+                .build();
+    }
+
+    @Bean
+    public JdbcBatchItemWriter<DiaryKeywordAndColor> diaryKeywordWriter() {
+        return new JdbcBatchItemWriterBuilder<DiaryKeywordAndColor>()
+                .dataSource(dataSource)
+                .sql("UPDATE diary SET main_keyword = ? WHERE diary_id = ?;")
+                .beanMapped()
+                .itemPreparedStatementSetter((item, ps) -> {
+                    ps.setString(1, item.getDiaryKeyword());
+                    ps.setInt(2, item.getDiaryId());
+                })
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JdbcCursorItemReader<Diary> diaryReader(
+            @Value("#{jobParameters[year]}") int year,
+            @Value("#{jobParameters[month]}") int month) {
+        return new JdbcCursorItemReaderBuilder<Diary>()
+                .fetchSize(chunkSize)
+                .dataSource(dataSource)
+                .rowMapper(new BeanPropertyRowMapper<>(Diary.class))
+                .sql("SELECT diary_id, member_id, diary_year, diary_month, main_color, main_keyword\n" +
+                        "FROM diary d\n" +
+                        "WHERE diary_year = " + year + " AND diary_month = " + month)
+                .name("diaryReader")
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<Diary, List<DiaryKeywordAndColor>> fetchDiaryColorProcessor() {
+        return diary -> {
+            List<String> colorList = colorService.getColor(diary.getMainColor());
+
+            List<DiaryKeywordAndColor> result = new ArrayList<>();
+            for (String color : colorList) {
+                DiaryKeywordAndColor item = new DiaryKeywordAndColor();
+                item.setDiaryId(diary.getDiaryId());
+                item.setDiaryColor(color);
+                result.add(item);
+            }
+
+            return result;
+        };
+    }
+
+    @Bean
+    public ItemWriter<List<DiaryKeywordAndColor>> setDiaryColors() {
+        return new ItemListWriter<DiaryKeywordAndColor>(new JdbcBatchItemWriterBuilder<DiaryKeywordAndColor>()
+                .dataSource(dataSource)
+                .sql("INSERT INTO diary_color VALUES (NULL, ?, ?)")
+                .beanMapped()
+                .itemPreparedStatementSetter((item, ps) -> {
+                    ps.setInt(1, item.getDiaryId());
+                    ps.setString(2, item.getDiaryColor());
+                })
+                .build());
+    }
+
+    @Bean
+    public JdbcBatchItemWriter<List<DiaryKeywordAndColor>> setDiaryMainColor() {
+        return new JdbcBatchItemWriterBuilder<List<DiaryKeywordAndColor>>()
+                .dataSource(dataSource)
+                .sql("UPDATE diary SET main_color = ? WHERE diary_id = ?;")
+                .beanMapped()
+                .itemPreparedStatementSetter((list, ps) -> {
+                    DiaryKeywordAndColor item = list.get(0);
+                    ps.setString(1, item.getDiaryColor());
+                    ps.setInt(2, item.getDiaryId());
+                })
+                .build();
+    }
+
+    @Bean
+    public CompositeItemWriter<List<DiaryKeywordAndColor>> diaryWriter() {
+        return new CompositeItemWriterBuilder<List<DiaryKeywordAndColor>>()
+                .delegates(Arrays.asList(setDiaryColors(), setDiaryMainColor()))
+                .build();
+    }
 }

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ColorService.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ColorService.java
@@ -1,0 +1,10 @@
+package com.ggukgguk.batch.extractKeyword.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.util.List;
+
+public interface ColorService {
+
+    public List<String> getColor(String keyword) throws JsonProcessingException;
+}

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ColorServiceImpl.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ColorServiceImpl.java
@@ -1,0 +1,64 @@
+package com.ggukgguk.batch.extractKeyword.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ColorServiceImpl implements ColorService {
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    @Value("${openai.apikey}")
+    private String OPEN_AI_API_KEY;
+
+    @Override
+    public List<String> getColor(String keyword) throws JsonProcessingException {
+        String url = "https://api.openai.com/v1/completions";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        httpHeaders.set("Authorization", "Bearer " + OPEN_AI_API_KEY);
+
+        String body = "{\n" +
+                "    \"model\": \"text-davinci-003\",\n" +
+                "    \"prompt\": \"A hex color code array related to '" + keyword + "'; Format: [\\\"#FFFFFF\\\"]; Length: 3.\",\n" +
+                "    \"max_tokens\": 40,\n" +
+                "    \"temperature\": 0\n" +
+                "  }";
+        System.out.println(body);
+
+        HttpEntity<?> requesMessage = new HttpEntity<>(body, httpHeaders);
+
+        HttpEntity<String> response = restTemplate.postForEntity(url, requesMessage, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+
+        HashMap<String, Object> dto = objectMapper.readValue(response.getBody(), HashMap.class);
+        List<Map> choices = (List<Map>)dto.get("choices");
+
+        String colorListRaw = (String)choices.get(0).get("text");
+
+        List<String> colorList = objectMapper.readValue(colorListRaw, List.class);
+        log.debug("Colors from AI: " + colorList);
+
+        return colorList;
+    }
+}

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ComprehendService.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ComprehendService.java
@@ -1,0 +1,10 @@
+package com.ggukgguk.batch.extractKeyword.service;
+
+import com.ggukgguk.batch.extractKeyword.vo.Record;
+import com.ggukgguk.batch.extractKeyword.vo.RecordKeyword;
+
+import java.util.List;
+
+public interface ComprehendService {
+    public List<RecordKeyword> extractKeywordFromRecord(Record record);
+}

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ComprehendServiceImpl.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/ComprehendServiceImpl.java
@@ -1,10 +1,10 @@
-package com.ggukgguk.batch.common.service;
+package com.ggukgguk.batch.extractKeyword.service;
 
 import com.ggukgguk.batch.extractKeyword.vo.Record;
 import com.ggukgguk.batch.extractKeyword.vo.RecordKeyword;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.comprehend.ComprehendClient;
 import software.amazon.awssdk.services.comprehend.model.ComprehendException;
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
-@StepScope
+@Component
 public class ComprehendServiceImpl implements ComprehendService {
     @Override
     public List<RecordKeyword> extractKeywordFromRecord(Record record) {

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/GgukggukNlpService.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/GgukggukNlpService.java
@@ -1,10 +1,12 @@
-package com.ggukgguk.batch.common.service;
+package com.ggukgguk.batch.extractKeyword.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.ggukgguk.batch.extractKeyword.vo.Keyword;
 import com.ggukgguk.batch.extractKeyword.vo.Record;
 import com.ggukgguk.batch.extractKeyword.vo.RecordKeyword;
 
 import java.util.List;
 
-public interface ComprehendService {
+public interface GgukggukNlpService {
     public List<RecordKeyword> extractKeywordFromRecord(Record record);
 }

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/GgukggukNlpServiceImpl.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/service/GgukggukNlpServiceImpl.java
@@ -1,0 +1,119 @@
+package com.ggukgguk.batch.extractKeyword.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ggukgguk.batch.extractKeyword.vo.Keyword;
+import com.ggukgguk.batch.extractKeyword.vo.Record;
+import com.ggukgguk.batch.extractKeyword.vo.RecordKeyword;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GgukggukNlpServiceImpl implements GgukggukNlpService {
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    @Value("${nlp.base-url}")
+    private String BASE_URL;
+
+    @Value("${nlp.num-of-keywords}")
+    private String NUM_OF_KEYWORDS;
+
+    @Override
+    public List<RecordKeyword> extractKeywordFromRecord(Record record) {
+        List<RecordKeyword> result = new ArrayList<RecordKeyword>();
+
+        String input = record.getRecordComment();
+
+        if (input == null || input.equals("")) {
+            result.add(RecordKeyword.builder()
+                    .recordId(record.getRecordId())
+                    .recordKeyword("")
+                    .build());
+            return result;
+        }
+
+        try {
+            sslTrustAllCerts();
+            String url = BASE_URL + "/nlp/keyword";
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+            String body = "{\n" +
+                    "\t\"text\": \"" + input + "\",\n" +
+                    "\t\"num\": " + NUM_OF_KEYWORDS + "\n" +
+                    "}";
+
+            HttpEntity<?> requesMessage = new HttpEntity<>(body, httpHeaders);
+
+            HttpEntity<String> response = restTemplate.postForEntity(url, requesMessage, String.class);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+
+            HashMap<String, Object> dto = objectMapper.readValue(response.getBody(), HashMap.class);
+            List<Map<String, Object>> keywords = (List<Map<String, Object>>)dto.get("data");
+            for (Map<String, Object> keyword : keywords) {
+                log.debug("추출 키워드: " + keyword.get("word"));
+                log.debug("점수: " + keyword.get("score") + "\n");
+                result.add(RecordKeyword.builder()
+                        .recordId(record.getRecordId())
+                        .recordKeyword((String)keyword.get("word"))
+                        .build());
+            }
+
+        } catch (Exception e) {
+            log.info("키워드 추출 요청중 예외가 발생했습니다.");
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+
+    /**
+     * SSL 인증서 검증 회피 (개발 서버용)
+     */
+    public void sslTrustAllCerts(){
+        TrustManager[] trustAllCerts = new TrustManager[] {
+                new X509TrustManager() {
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) { }
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) { }
+                }
+        };
+
+        SSLContext sc;
+
+        try {
+            sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/vo/Diary.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/vo/Diary.java
@@ -1,0 +1,17 @@
+package com.ggukgguk.batch.extractKeyword.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Diary {
+    private int diaryId;
+    private String memberId;
+    private String diaryYear;
+    private String diaryMonth;
+    private String mainColor;
+    private String mainKeyword;
+}

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/vo/DiaryKeywordAndColor.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/vo/DiaryKeywordAndColor.java
@@ -1,0 +1,16 @@
+package com.ggukgguk.batch.extractKeyword.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryKeywordAndColor {
+    int diaryKeywordId;
+    int diaryId;
+    String diaryKeyword;
+    int diaryFreq;
+    String diaryColor;
+}

--- a/batch/src/main/java/com/ggukgguk/batch/extractKeyword/vo/Keyword.java
+++ b/batch/src/main/java/com/ggukgguk/batch/extractKeyword/vo/Keyword.java
@@ -1,0 +1,13 @@
+package com.ggukgguk.batch.extractKeyword.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Keyword {
+    private String word;
+    private float score;
+}


### PR DESCRIPTION
- OpenAI API를 이용하여 추출한 키워드로부터 대표 키워드를 diary 테이블의 main_keyword에 쓰도록 구현.
- 대표 키워드로부터 색상을 추천받아, diary_color 테이블에 추가하고, 첫 색상을 diary 테이블의 main_color에 쓰도록 구현.
- 키워드 추출시 기존 AWS Comprehend가 아닌 자체 서버의 기능을 사용하도록 수정